### PR TITLE
Fix count() Warnings during "bin/zf create"  on php7.3

### DIFF
--- a/library/Zend/Tool/Project/Profile/Resource/Container.php
+++ b/library/Zend/Tool/Project/Profile/Resource/Container.php
@@ -383,7 +383,7 @@ class Zend_Tool_Project_Profile_Resource_Container implements RecursiveIterator,
      */
     public function hasChildren()
     {
-        return (count($this->_subResources > 0)) ? true : false;
+        return (count($this->_subResources) > 0) ? true : false;
     }
 
     /**


### PR DESCRIPTION
zf create project warning PHP7.3 count(): Parameter must be an array or an object #15
